### PR TITLE
adding access of parent.frame to eval

### DIFF
--- a/R/rmcorr.R
+++ b/R/rmcorr.R
@@ -28,15 +28,15 @@ rmcorr <- function(participant, measure1, measure2, dataset,
     
     args <- as.list(match.call())
     
-    Participant <- eval(args$participant, dataset)
+    Participant <- eval(args$participant, dataset, parent.frame())
     if (class(Participant) == "character"){
         Participant <- get(Participant, dataset)
     }
-    Measure1 <- eval(args$measure1, dataset)
+    Measure1 <- eval(args$measure1, dataset, parent.frame())
     if (class(Measure1) == "character"){
         Measure1 <- get(Measure1, dataset)
     }
-    Measure2 <- eval(args$measure2, dataset)
+    Measure2 <- eval(args$measure2, dataset, parent.frame())
     if (class(Measure2) == "character"){
         Measure2 <- get(Measure2, dataset)
     }
@@ -148,5 +148,4 @@ print.rmc <- function(x, ...) {
     cat(x$CI)
     
 }   
-    
-    
+


### PR DESCRIPTION
I call `rmcorr` dynamically, eg like this:

```
res = rmcorr(PatientId, var_pair[1], var_pair[2], clinical_data)
```

where `PatientId` is one of the columns of `clinical_data`, while `var_pair` is a vector of strings and `clinical_data` is a data.frame. This caused a crash in the following line of rmcorr:

```
Measure1 <- eval(args$measure1, dataset)
```

That's because the `eval` function, since `dataset` is neither a `list` nor a `pair.list`, uses an empty environment (`baseenv()`) for this evaluation. It would therefore complain that `var_pair` does not exist.

Passing the parent frame, like R functions usually do too, solves this by making `var_pair` accessible to eval.