### PR TITLE
Add website to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,5 +51,5 @@ Suggests:
     patchwork
 VignetteBuilder: knitr
 Config/testthat/edition: 3
-URL: https://github.com/lmarusich/rmcorr
+URL: https://lmarusich.github.io/rmcorr/, https://github.com/lmarusich/rmcorr
 BugReports: https://github.com/lmarusich/rmcorr/issues


### PR DESCRIPTION
for discoverability and linking https://blog.r-hub.io/2019/12/10/urls/, it is recommended that the package website appears in DESCRIPTION and in _pkgdown.yml